### PR TITLE
golangci: disable scopelint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     - nolintlint
     - prealloc
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - dupl
     - errcheck
     - errorlint
+    - exportloopref
     - funlen
     - gochecknoglobals
     - gochecknoinits


### PR DESCRIPTION
```
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref. 
```